### PR TITLE
no tab will be selected when children's length changed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,11 +108,15 @@ const ScrollableTabView = createReactClass({
   },
 
   componentWillReceiveProps(props) {
+    let currentPage = this.state.currentPage;
     if (props.children !== this.props.children) {
-      this.updateSceneKeys({ page: this.state.currentPage, children: props.children, });
+      if (currentPage >= props.children.length) {
+        currentPage = 0;
+      }
+      this.updateSceneKeys({ page: currentPage, children: props.children, });
     }
 
-    if (props.page >= 0 && props.page !== this.state.currentPage) {
+    if (props.page >= 0 && props.page !== currentPage) {
       this.goToPage(props.page);
     }
   },


### PR DESCRIPTION
if new children's length is less than the old ones, no tab will be selected, even use the 'page' or 'initialPage' prop, the behavir is different between android and ios.
This fix will select the 0 index tab when new children's length is less then the old ones.
