### PR TITLE
Remove an unused line that prompts error on React Native 0.61.4

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ const {
   InteractionManager,
 } = ReactNative;
 
-const ViewPagerAndroid = require('@react-native-community/viewpager');
 const TimerMixin = require('react-timer-mixin');
 const ViewPager = require('@react-native-community/viewpager');
 
@@ -339,7 +338,7 @@ const ScrollableTabView = createReactClass({
     if (!width || width <= 0 || Math.round(width) === Math.round(this.state.containerWidth)) {
       return;
     }
-    
+
     if (Platform.OS === 'ios') {
       const containerWidthAnimatedValue = new Animated.Value(width);
       // Need to call __makeNative manually to avoid a native animated bug. See


### PR DESCRIPTION
It seems that this unused line referencing the deprecated `ViewPagerAndroid` may cause error in runtime. 
```
ViewPagerAndroid has been removed from React Native.
```

This may also related to the removal of `ViewPagerAndroid` in https://github.com/react-native-community/react-native-viewpager/pull/64 