### PR TITLE
ViewPagerAndroid is not used

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ const {
   InteractionManager,
 } = ReactNative;
 
-const ViewPagerAndroid = require('@react-native-community/viewpager');
 const TimerMixin = require('react-timer-mixin');
 const ViewPager = require('@react-native-community/viewpager');
 


### PR DESCRIPTION
ViewPagerAndroid is not used and causes an error in Expo 36.0.0