### PR TITLE
fix: onChangeTab called twice on Android

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ const ScrollableTabView = createReactClass({
     ScrollableTabBar,
   },
   scrollOnMountCalled: false,
+  tabWillChangeWithoutGesture: false,
 
   propTypes: {
     tabBarPosition: PropTypes.oneOf(['top', 'bottom', 'overlayTop', 'overlayBottom', ]),
@@ -141,6 +142,7 @@ const ScrollableTabView = createReactClass({
       }
     } else {
       if (this.scrollView) {
+        this.tabWillChangeWithoutGesture = true;
         if (this.props.scrollWithoutAnimation) {
           this.scrollView.getNode().setPageWithoutAnimation(pageNumber);
         } else {
@@ -305,10 +307,11 @@ const ScrollableTabView = createReactClass({
     }
 
     const currentPage = this.state.currentPage;
-    this.updateSceneKeys({
+    !this.tabWillChangeWithoutGesture && this.updateSceneKeys({
       page: localNextPage,
       callback: this._onChangeTab.bind(this, currentPage, localNextPage),
     });
+    this.tabWillChangeWithoutGesture = false;
   },
 
   _onChangeTab(prevPage, currentPage) {


### PR DESCRIPTION
## Summary
This will fix duplicated tab updates on android (resolve #1060)

`onPageSelected={this._updateSelectedPage}` ViewPager prop causes onChangeTab to be called twice when change tabs without any gesture actions

(I used onChangeTab with double click a tab for reset scroll-offset in tab-view or reset tab-index in nested tab-views)

### [Before] When user clicked tab buttons
1. `goToPage`
2. **`updateSceneKeys` and `onChangeTab`** (index 0,1)
3. Screen Update
4. goToPage called `onPageSelected={_updateSelectedPage}`
5. **`updateSceneKeys` and `onChangeTab`** (index 1,1)
6. Screen Update

### [After] When user clicked tab buttons
1. `goToPage`
2. **`updateSceneKeys` and `onChangeTab`** (index 0,1)
3. Screen Update

### [Before & After] When user swiped tab views
1. Swipe
2. `onPageSelected={_updateSelectedPage}`
3. `updateSceneKeys` and `onChangeTab` (index 0,1)
4. Screen Update