### PR TITLE
add keyboardShouldPersistTaps prop to ScrollView

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ const ScrollableTabView = createReactClass({
   propTypes: {
     tabBarPosition: PropTypes.oneOf(['top', 'bottom', 'overlayTop', 'overlayBottom', ]),
     initialPage: PropTypes.number,
+    keyboardShouldPersistTaps: PropTypes.oneOf(['never', 'always', 'handled', ]),
     page: PropTypes.number,
     onChangeTab: PropTypes.func,
     onScroll: PropTypes.func,
@@ -246,6 +247,7 @@ const ScrollableTabView = createReactClass({
         directionalLockEnabled
         alwaysBounceVertical={false}
         keyboardDismissMode="on-drag"
+        keyboardShouldPersistTaps={this.props.keyboardShouldPersistTaps || 'never'}
         {...this.props.contentProps}
       >
           {scenes}
@@ -258,6 +260,7 @@ const ScrollableTabView = createReactClass({
         initialPage={this.props.initialPage}
         onPageSelected={this._updateSelectedPage}
         keyboardDismissMode="on-drag"
+        keyboardShouldPersistTaps={this.props.keyboardShouldPersistTaps || 'never'}
         scrollEnabled={!this.props.locked}
         onPageScroll={Animated.event(
           [{


### PR DESCRIPTION
Adds `keyboardShouldPersistTaps` to iOS ScrollView to better handle double taps when the keyboard is visible.