### PR TITLE
[FIX] Maximum depth limit exceeded - using page props with onChangeTab

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ const ScrollableTabView = createReactClass({
       this.updateSceneKeys({ page: this.state.currentPage, children: this.props.children, });
     }
 
-    if (this.props.page >= 0 && this.props.page !== this.state.currentPage) {
+    if (this.props.page !== prevProps.page && this.props.page >= 0 && this.props.page !== this.state.currentPage) {
       this.goToPage(this.props.page);
     }
   },


### PR DESCRIPTION
Handling infinite rerendering of tab view when using page props with onChangeTab