### PR TITLE
Use deprecate-react-native-prop-types

### DIFF
--- a/DefaultTabBar.js
+++ b/DefaultTabBar.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const { ViewPropTypes } = ReactNative = require('react-native');
+const { ViewPropTypes } = ReactNative = require('deprecated-react-native-prop-types');
 const PropTypes = require('prop-types');
 const createReactClass = require('create-react-class');
 const {

--- a/ScrollableTabBar.js
+++ b/ScrollableTabBar.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const { ViewPropTypes } = ReactNative = require('react-native');
+const { ViewPropTypes } = ReactNative = require('deprecated-react-native-prop-types');
 const PropTypes = require('prop-types');
 const createReactClass = require('create-react-class');
 const {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const React = require('react');
 const { Component } = React;
-const { ViewPropTypes } = ReactNative = require('react-native');
+const { ViewPropTypes } = ReactNative = require('deprecated-react-native-prop-types');
 const createReactClass = require('create-react-class');
 const PropTypes = require('prop-types');
 const {
@@ -342,7 +342,7 @@ const ScrollableTabView = createReactClass({
     if (!width || width <= 0 || Math.round(width) === Math.round(this.state.containerWidth)) {
       return;
     }
-    
+
     if (Platform.OS === 'ios') {
       const containerWidthAnimatedValue = new Animated.Value(width);
       // Need to call __makeNative manually to avoid a native animated bug. See

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "@react-native-community/viewpager": "3.3.0",
     "create-react-class": "^15.6.2",
     "prop-types": "^15.6.0",
-    "react-timer-mixin": "^0.13.3"
+    "react-timer-mixin": "^0.13.3",
+    "deprecated-react-native-prop-types": "^2.3.0"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
Platforms affected
All

What does this PR do?
RN 0.68 has deprecated and will eventually remove ViewPropTypes (see post). This adds the deprecated-react-native-prop-types package and uses that instead.

What testing has been done on this change?
Local testing, to ensure the deprecation warning has been removed.